### PR TITLE
Add concurrent send example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ library features:
 - `Test.FileTransfer` – streaming data between client and server
 - `Test.Metadata` – sending messages with metadata maps
 - `Test.Parallel` – multiple clients sending concurrently
+- `Test.MultiThread` – multiple goroutines sending on one client connection
 - `Test.Reconnect` – reconnect logic for unreliable networks
 - `Test.SyncMessages` – synchronous request/response messaging
 

--- a/examples/Test.MultiThread/main.go
+++ b/examples/Test.MultiThread/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/WasimAhmad/watsontcp-go/client"
+	"github.com/WasimAhmad/watsontcp-go/message"
+	"github.com/WasimAhmad/watsontcp-go/server"
+)
+
+const addr = "127.0.0.1:9300"
+
+func main() {
+	srvCb := server.Callbacks{
+		OnMessage: func(id string, msg *message.Message, data []byte) {
+			fmt.Printf("[%s] %s\n", id, string(data))
+		},
+	}
+	srv := server.New(addr, nil, srvCb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+
+	cli := client.New(addr, nil, client.Callbacks{}, nil)
+	if err := cli.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer cli.Disconnect()
+
+	// Client.Send is safe for concurrent use by multiple goroutines.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				txt := fmt.Sprintf("goroutine %d msg %d", n, j)
+				if err := cli.Send(&message.Message{}, []byte(txt)); err != nil {
+					log.Println("send:", err)
+					return
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- add `Test.MultiThread` example demonstrating concurrent sends on one client
- document new example in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e9e09f13c832e9fabdccbefd6fe9b