### PR TITLE
Add nonexistent server example

### DIFF
--- a/examples/Test.NonExistentServer/main.go
+++ b/examples/Test.NonExistentServer/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+	"net"
+
+	"github.com/WasimAhmad/watsontcp-go/client"
+)
+
+func main() {
+	addr := "127.0.0.1:65534" // assume no server is listening
+	cli := client.New(addr, nil, client.Callbacks{}, nil)
+	if err := cli.Connect(); err != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			log.Printf("connection to %s timed out: %v", addr, err)
+		} else {
+			log.Printf("unable to connect to %s: %v", addr, err)
+		}
+		log.Println("Ensure the address is correct, the server is running, and consider retry logic for transient failures.")
+		return
+	}
+	defer cli.Disconnect()
+}


### PR DESCRIPTION
## Summary
- add example to show connecting to an address with no server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e9e0ad1fc832ebde48b8669f7af07